### PR TITLE
add method to apply tinyify to a separate browserify pipeline, closes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,25 @@
 var packFlat = require('browser-pack-flat/plugin')
+var packFlatStream = require('browser-pack-flat')
 var commonShake = require('common-shakeify')
 var unassertify = require('unassertify')
 var uglify = require('minify-stream')
 var envify = require('envify/custom')
 var uglifyify = require('uglifyify')
+
+function makeUglifyOptions (debug) {
+  var uglifyOpts = {
+    output: {
+      ascii_only: true
+    },
+    mangle: {
+      safari10: true
+    }
+  }
+  if (!debug) {
+    uglifyOpts.sourceMap = false
+  }
+  return uglifyOpts
+}
 
 module.exports = function (b, opts) {
   if (typeof b !== 'object') {
@@ -11,7 +27,8 @@ module.exports = function (b, opts) {
   }
 
   opts = Object.assign({
-    flat: true
+    flat: true,
+    env: {}
   }, opts)
 
   var env = Object.assign({
@@ -42,16 +59,26 @@ module.exports = function (b, opts) {
   b.plugin(commonShake)
 
   // Minify the final output.
-  var uglifyOpts = {
-    output: {
-      ascii_only: true
-    },
-    mangle: {
-      safari10: true
-    }
-  }
-  if (!b._options.debug) {
-    uglifyOpts.sourceMap = false
-  }
+  var uglifyOpts = makeUglifyOptions(b._options.debug)
   b.pipeline.get('pack').push(uglify(uglifyOpts))
+}
+
+module.exports.applyToPipeline = function applyToPipeline (pipeline, opts) {
+  opts = Object.assign({
+    flat: true,
+    debug: false,
+    basedir: process.cwd()
+  }, opts)
+
+  if (opts.flat) {
+    pipeline.get('pack').splice(0, 1, packFlatStream({
+      raw: true,
+      debug: opts.debug,
+      basedir: opts.basedir
+    }))
+  }
+
+  // Minify the final output.
+  var uglifyOpts = makeUglifyOptions(opts.debug)
+  pipeline.get('pack').push(uglify(uglifyOpts))
 }


### PR DESCRIPTION
a take on #1

This would be used programmatically as

```js
b.plugin(tinyify)
b.on('factor.pipeline', function (file, pipeline) {
  tinyify.applyToPipeline(pipeline, b._options)
})
b.plugin(factorBundle, { /* opts */ })
```

and would [flatten](https://github.com/goto-bus-stop/browser-pack-flat) and minify the pipeline.